### PR TITLE
Allow customizing the time label text style

### DIFF
--- a/lib/audio_video_progress_bar.dart
+++ b/lib/audio_video_progress_bar.dart
@@ -39,6 +39,7 @@ class ProgressBar extends LeafRenderObjectWidget {
     this.thumbRadius = 10.0,
     this.thumbColor,
     this.timeLabelLocation,
+    this.timeLabelTextStyle,
   }) : super(key: key);
 
   /// The elapsed playing time of the media.
@@ -99,11 +100,16 @@ class ProgressBar extends LeafRenderObjectWidget {
   /// put them on the sides or remove them altogether.
   final TimeLabelLocation? timeLabelLocation;
 
+  /// The [TextStyle] used by the time labels.
+  ///
+  /// By default it is [TextTheme.bodyText1].
+  final TextStyle? timeLabelTextStyle;
+
   @override
   _RenderProgressBar createRenderObject(BuildContext context) {
     final theme = Theme.of(context);
     final primaryColor = theme.colorScheme.primary;
-    final textStyle = theme.textTheme.bodyText1;
+    final textStyle = timeLabelTextStyle ?? theme.textTheme.bodyText1;
     return _RenderProgressBar(
       progress: progress,
       total: total,
@@ -125,7 +131,7 @@ class ProgressBar extends LeafRenderObjectWidget {
       BuildContext context, _RenderProgressBar renderObject) {
     final theme = Theme.of(context);
     final primaryColor = theme.colorScheme.primary;
-    final textStyle = theme.textTheme.bodyText1;
+    final textStyle = timeLabelTextStyle ?? theme.textTheme.bodyText1;
     renderObject
       ..progress = progress
       ..total = total
@@ -388,6 +394,7 @@ class _RenderProgressBar extends RenderBox {
     if (_timeLabelTextStyle == value) return;
     _timeLabelTextStyle = value;
     markNeedsLayout();
+    markNeedsPaint();
   }
 
   // The smallest that this widget would ever want to be.

--- a/lib/audio_video_progress_bar.dart
+++ b/lib/audio_video_progress_bar.dart
@@ -163,6 +163,8 @@ class ProgressBar extends LeafRenderObjectWidget {
     properties.add(ColorProperty('thumbColor', thumbColor));
     properties
         .add(StringProperty('timeLabelLocation', timeLabelLocation.toString()));
+    properties
+        .add(DiagnosticsProperty('timeLabelTextStyle', timeLabelTextStyle));
   }
 }
 

--- a/test/audio_video_progress_bar_test.dart
+++ b/test/audio_video_progress_bar_test.dart
@@ -32,6 +32,7 @@ void main() {
         thumbRadius: 20.0,
         thumbColor: Color(0x00000000),
         timeLabelLocation: TimeLabelLocation.sides,
+        timeLabelTextStyle: const TextStyle(color: Color(0x00000000)),
       ),
     );
 
@@ -49,6 +50,8 @@ void main() {
     expect(progressBar.thumbRadius, 20.0);
     expect(progressBar.thumbColor, Color(0x00000000));
     expect(progressBar.timeLabelLocation, TimeLabelLocation.sides);
+    expect(progressBar.timeLabelTextStyle,
+        const TextStyle(color: Color(0x00000000)));
   });
 
   testWidgets('TimeLabelLocation.below size correct',


### PR DESCRIPTION
This PR adds a new constructor argument, `timeLabelTextStyle`, that sets a custom time label text style.

Fixes #1.