### PR TITLE
Allow customizing the thumb glow radius

### DIFF
--- a/lib/audio_video_progress_bar.dart
+++ b/lib/audio_video_progress_bar.dart
@@ -38,6 +38,7 @@ class ProgressBar extends LeafRenderObjectWidget {
     this.bufferedBarColor,
     this.thumbRadius = 10.0,
     this.thumbColor,
+    this.thumbGlowRadius = 30.0,
     this.timeLabelLocation,
   }) : super(key: key);
 
@@ -93,6 +94,12 @@ class ProgressBar extends LeafRenderObjectWidget {
   /// By default it is your theme's primary color.
   final Color? thumbColor;
 
+  /// The radius of the circle for the pressed-down effect of the moveable
+  /// progress bar thumb.
+  ///
+  /// By default it is 30.
+  final double thumbGlowRadius;
+
   /// The location for the [progress] and [total] duration text labels.
   ///
   /// By default the labels appear under the progress bar but you can also
@@ -115,6 +122,7 @@ class ProgressBar extends LeafRenderObjectWidget {
       bufferedBarColor: bufferedBarColor ?? primaryColor.withOpacity(0.24),
       thumbRadius: thumbRadius,
       thumbColor: thumbColor ?? primaryColor,
+      thumbGlowRadius: thumbGlowRadius,
       timeLabelLocation: timeLabelLocation ?? TimeLabelLocation.below,
       timeLabelTextStyle: textStyle,
     );
@@ -137,6 +145,7 @@ class ProgressBar extends LeafRenderObjectWidget {
       ..bufferedBarColor = bufferedBarColor ?? primaryColor.withOpacity(0.24)
       ..thumbRadius = thumbRadius
       ..thumbColor = thumbColor ?? primaryColor
+      ..thumbGlowRadius = thumbGlowRadius
       ..timeLabelLocation = timeLabelLocation ?? TimeLabelLocation.below
       ..timeLabelTextStyle = textStyle;
   }
@@ -155,6 +164,7 @@ class ProgressBar extends LeafRenderObjectWidget {
     properties.add(ColorProperty('bufferedBarColor', bufferedBarColor));
     properties.add(DoubleProperty('thumbRadius', thumbRadius));
     properties.add(ColorProperty('thumbColor', thumbColor));
+    properties.add(DoubleProperty('thumbGlowRadius', thumbGlowRadius));
     properties
         .add(StringProperty('timeLabelLocation', timeLabelLocation.toString()));
   }
@@ -172,6 +182,7 @@ class _RenderProgressBar extends RenderBox {
     required Color bufferedBarColor,
     double thumbRadius = 20.0,
     required Color thumbColor,
+    double thumbGlowRadius = 30.0,
     required TimeLabelLocation timeLabelLocation,
     TextStyle? timeLabelTextStyle,
   })  : _progress = progress,
@@ -184,6 +195,7 @@ class _RenderProgressBar extends RenderBox {
         _bufferedBarColor = bufferedBarColor,
         _thumbRadius = thumbRadius,
         _thumbColor = thumbColor,
+        _thumbGlowRadius = thumbGlowRadius,
         _timeLabelLocation = timeLabelLocation,
         _timeLabelTextStyle = timeLabelTextStyle {
     _drag = HorizontalDragGestureRecognizer()
@@ -368,6 +380,15 @@ class _RenderProgressBar extends RenderBox {
   set thumbRadius(double value) {
     if (_thumbRadius == value) return;
     _thumbRadius = value;
+    markNeedsLayout();
+  }
+
+  /// The length of the radius of the pressed-down effect of the moveable thumb.
+  double get thumbGlowRadius => _thumbGlowRadius;
+  double _thumbGlowRadius;
+  set thumbGlowRadius(double value) {
+    if (_thumbGlowRadius == value) return;
+    _thumbGlowRadius = value;
     markNeedsLayout();
   }
 
@@ -595,7 +616,7 @@ class _RenderProgressBar extends RenderBox {
     final center = Offset(thumbDx, localSize.height / 2);
     if (_userIsDraggingThumb) {
       final thumbGlowPaint = Paint()..color = thumbColor.withAlpha(80);
-      canvas.drawCircle(center, 30, thumbGlowPaint);
+      canvas.drawCircle(center, thumbGlowRadius, thumbGlowPaint);
     }
     canvas.drawCircle(center, thumbRadius, thumbPaint);
   }

--- a/test/audio_video_progress_bar_test.dart
+++ b/test/audio_video_progress_bar_test.dart
@@ -31,6 +31,7 @@ void main() {
         bufferedBarColor: Color(0x00000000),
         thumbRadius: 20.0,
         thumbColor: Color(0x00000000),
+        thumbGlowRadius: 50.0,
         timeLabelLocation: TimeLabelLocation.sides,
       ),
     );
@@ -48,6 +49,7 @@ void main() {
     expect(progressBar.bufferedBarColor, Color(0x00000000));
     expect(progressBar.thumbRadius, 20.0);
     expect(progressBar.thumbColor, Color(0x00000000));
+    expect(progressBar.thumbGlowRadius, 50.0);
     expect(progressBar.timeLabelLocation, TimeLabelLocation.sides);
   });
 


### PR DESCRIPTION
This PR adds a new constructor argument, `thumbGlowRadius`, that sets a custom thumb glow radius.