### PR TITLE
fix thumb position when total changed

### DIFF
--- a/lib/audio_video_progress_bar.dart
+++ b/lib/audio_video_progress_bar.dart
@@ -584,6 +584,9 @@ class _RenderProgressBar extends RenderBox {
       _clearLabelCache();
     }
     _total = value;
+    if (!_userIsDraggingThumb) {
+      _thumbValue = _proportionOfTotal(progress);
+    }
     markNeedsPaint();
   }
 


### PR DESCRIPTION
Update thumb position when total changed as same as progress changed.

This could be related to #26