### PR TITLE
Format negative Duration String

### DIFF
--- a/lib/audio_video_progress_bar.dart
+++ b/lib/audio_video_progress_bar.dart
@@ -1029,20 +1029,21 @@ class _RenderProgressBar extends RenderBox {
     if (timeIsNegative) {
       newTime = time.abs();
     }
-
-    final minutes = newTime.inMinutes
-        .remainder(Duration.minutesPerHour)
-        .toString()
-        .padLeft(2, '0');
+    final minutes =
+        newTime.inMinutes.remainder(Duration.minutesPerHour).toString();
     final seconds = newTime.inSeconds
         .remainder(Duration.secondsPerMinute)
         .toString()
         .padLeft(2, '0');
-    final hours = newTime.inHours > 0 ? '${newTime.inHours}:' : '';
+
     if (timeIsNegative) {
-      return "-$hours$minutes:$seconds";
+      return newTime.inHours > 0
+          ? "-${newTime.inHours}:${minutes.padLeft(2, "0")}:$seconds"
+          : "-$minutes:$seconds";
     } else {
-      return "$hours$minutes:$seconds";
+      return newTime.inHours > 0
+          ? "${time.inHours}:${minutes.padLeft(2, "0")}:$seconds"
+          : "$minutes:$seconds";
     }
   }
 

--- a/lib/audio_video_progress_bar.dart
+++ b/lib/audio_video_progress_bar.dart
@@ -1024,15 +1024,26 @@ class _RenderProgressBar extends RenderBox {
   }
 
   String _getTimeString(Duration time) {
-    final minutes =
-        time.inMinutes.remainder(Duration.minutesPerHour).toString();
-    final seconds = time.inSeconds
+    Duration newTime = time;
+    bool timeIsNegative = time.isNegative;
+    if (timeIsNegative) {
+      newTime = time.abs();
+    }
+
+    final minutes = newTime.inMinutes
+        .remainder(Duration.minutesPerHour)
+        .toString()
+        .padLeft(2, '0');
+    final seconds = newTime.inSeconds
         .remainder(Duration.secondsPerMinute)
         .toString()
         .padLeft(2, '0');
-    return time.inHours > 0
-        ? "${time.inHours}:${minutes.padLeft(2, "0")}:$seconds"
-        : "$minutes:$seconds";
+    final hours = newTime.inHours > 0 ? '${newTime.inHours}:' : '';
+    if (timeIsNegative) {
+      return "-$hours$minutes:$seconds";
+    } else {
+      return "$hours$minutes:$seconds";
+    }
   }
 
   @override


### PR DESCRIPTION
Currently, if you have a negative Duration, the String returned
from _getTimeString appears as -1:-2:-47.

This change checks if the Duration value passed in is negative.
If it is, we set the timeIsNegative bool to true and convert the
Duration value to a positive number using .abs(). If the Duration
is negative then we return a String with a prefixed with '-'.

With this change, the
String will appears as -1:02:47.