### PR TITLE
Fix String format when Duration is negative

### DIFF
--- a/lib/audio_video_progress_bar.dart
+++ b/lib/audio_video_progress_bar.dart
@@ -1027,7 +1027,7 @@ class _RenderProgressBar extends RenderBox {
     Duration newTime = time;
     bool timeIsNegative = time.isNegative;
     if (timeIsNegative) {
-      newTime = time.abs();
+      newTime = "0:00";
     }
     final minutes =
         newTime.inMinutes.remainder(Duration.minutesPerHour).toString();

--- a/lib/audio_video_progress_bar.dart
+++ b/lib/audio_video_progress_bar.dart
@@ -1017,22 +1017,34 @@ class _RenderProgressBar extends RenderBox {
   }
 
   double _proportionOfTotal(Duration duration) {
-    if (total.inMilliseconds == 0) {
+    if (total.inMilliseconds == 0 || duration.isNegative) {
       return 0.0;
     }
     return duration.inMilliseconds / total.inMilliseconds;
   }
 
   String _getTimeString(Duration time) {
+    Duration newTime = time;
+    bool timeIsNegative = time.isNegative;
+    if (timeIsNegative) {
+      newTime = time.abs();
+    }
     final minutes =
-        time.inMinutes.remainder(Duration.minutesPerHour).toString();
-    final seconds = time.inSeconds
+        newTime.inMinutes.remainder(Duration.minutesPerHour).toString();
+    final seconds = newTime.inSeconds
         .remainder(Duration.secondsPerMinute)
         .toString()
         .padLeft(2, '0');
-    return time.inHours > 0
-        ? "${time.inHours}:${minutes.padLeft(2, "0")}:$seconds"
-        : "$minutes:$seconds";
+
+    if (timeIsNegative) {
+      return newTime.inHours > 0
+          ? "-${newTime.inHours}:${minutes.padLeft(2, "0")}:$seconds"
+          : "-$minutes:$seconds";
+    } else {
+      return newTime.inHours > 0
+          ? "${time.inHours}:${minutes.padLeft(2, "0")}:$seconds"
+          : "$minutes:$seconds";
+    }
   }
 
   @override


### PR DESCRIPTION
Currently, if you have a negative Duration, the String returned
from _getTimeString appears as -1:-2:-47.

This change checks if the Duration value passed in is negative.
If it is, we set the timeIsNegative bool to true and convert the
Duration value to a positive number using .abs(). If the Duration
is negative then we return a String with a prefixed with '-'.

With this change, the String will appears as -1:02:47.

Also check if duration.isNegative when setting the progress bar
progress length to prevent it from going too far to the left when
the value is negative.

ps-id: e7372e7d-3ff1-428a-96f3-879b40ee32a6