### PR TITLE
Fix horizontal drag and tap when ancestors have competing gestures.

### DIFF
--- a/lib/audio_video_progress_bar.dart
+++ b/lib/audio_video_progress_bar.dart
@@ -82,6 +82,8 @@ class ProgressBar extends LeafRenderObjectWidget {
     this.onDragStart,
     this.onDragUpdate,
     this.onDragEnd,
+    this.onTap,
+    this.seekOnTap = true,
     this.barHeight = 5.0,
     this.baseBarColor,
     this.progressBarColor,
@@ -123,6 +125,10 @@ class ProgressBar extends LeafRenderObjectWidget {
   /// If you want continuous duration updates as the user moves the thumb,
   /// see [onDragUpdate], where the provided [ThumbDragDetails] has a
   /// `timeStamp` with the seek duration on it.
+  ///
+  /// By default, this callback will also be invoked for tap events, with the
+  /// duration set based on the tap location. If this behavior of seeking on tap
+  /// is not desired, set the [seekOnTap] toggle to false.
   final ValueChanged<Duration>? onSeek;
 
   /// A callback when the user starts to move the thumb.
@@ -165,6 +171,34 @@ class ProgressBar extends LeafRenderObjectWidget {
   ///
   /// This method is called directly before [onSeek].
   final VoidCallback? onDragEnd;
+
+  /// A callback when the user finishes tapping on the progress bar.
+  ///
+  /// This is called only once when the tap gesture is considered complete.
+  /// (E.g. When the user tapped  without dragging or the user clicked with the
+  /// primary pointing device, such as a mouse.)
+  ///
+  /// The behavior of this callback is not impacted by [seekOnTap].
+  /// But if [seekOnTap] is set to true, the [onTap] will be invoked before
+  /// [onSeek]
+  final VoidCallback? onTap;
+
+  /// Whether a tap on the progress bar will cause the tracking thumb to move
+  /// to the location of the tap and cause the onSeek to be invoked.
+  ///
+  /// The default is `true` and this means that a tap will cause the thumb to
+  /// move and invoke an onSeek when the tap gesture is completed.
+  ///
+  /// This doesn't impact the drag behavior. Therefore, if the user taps and
+  /// then drags, the tracking thumb will follow the drag and invoke the drag
+  /// callbacks.
+  ///
+  /// It is useful to set this to 'false', if accidental taping on the progress
+  /// bar should not result in invoking a seeking / dragging behavior. It is
+  /// also useful to implement alternative interactions such as displaying a
+  /// more detailed progress bar, on tap and resetting it to a collapsed
+  /// or mini version by default.
+  final bool seekOnTap;
 
   /// The vertical thickness of the progress bar.
   final double barHeight;
@@ -265,6 +299,8 @@ class ProgressBar extends LeafRenderObjectWidget {
       onDragStart: onDragStart,
       onDragUpdate: onDragUpdate,
       onDragEnd: onDragEnd,
+      onTap: onTap,
+      seekOnTap: seekOnTap,
       barHeight: barHeight,
       baseBarColor: baseBarColor ?? primaryColor.withOpacity(0.24),
       progressBarColor: progressBarColor ?? primaryColor,
@@ -298,6 +334,8 @@ class ProgressBar extends LeafRenderObjectWidget {
       ..onDragStart = onDragStart
       ..onDragUpdate = onDragUpdate
       ..onDragEnd = onDragEnd
+      ..onTap = onTap
+      ..seekOnTap = seekOnTap
       ..barHeight = barHeight
       ..baseBarColor = baseBarColor ?? primaryColor.withOpacity(0.24)
       ..progressBarColor = progressBarColor ?? primaryColor
@@ -332,6 +370,17 @@ class ProgressBar extends LeafRenderObjectWidget {
         ifNull: 'unimplemented'));
     properties.add(ObjectFlagProperty<VoidCallback>('onDragEnd', onDragEnd,
         ifNull: 'unimplemented'));
+    properties.add(ObjectFlagProperty<VoidCallback>('onTap', onTap,
+        ifNull: 'unimplemented'));
+    properties.add(
+      FlagProperty(
+        'seekOnTap',
+        value: seekOnTap,
+        ifTrue: 'will call onSeek when tapped',
+        ifFalse: "won't call onSeek when tapped",
+        showName: true,
+      ),
+    );
     properties.add(DoubleProperty('barHeight', barHeight));
     properties.add(ColorProperty('baseBarColor', baseBarColor));
     properties.add(ColorProperty('progressBarColor', progressBarColor));
@@ -341,8 +390,15 @@ class ProgressBar extends LeafRenderObjectWidget {
     properties.add(ColorProperty('thumbColor', thumbColor));
     properties.add(ColorProperty('thumbGlowColor', thumbGlowColor));
     properties.add(DoubleProperty('thumbGlowRadius', thumbGlowRadius));
-    properties.add(FlagProperty('thumbCanPaintOutsideBar',
-        value: thumbCanPaintOutsideBar));
+    properties.add(
+      FlagProperty(
+        'thumbCanPaintOutsideBar',
+        value: thumbCanPaintOutsideBar,
+        ifTrue: 'true',
+        ifFalse: 'false',
+        showName: true,
+      ),
+    );
     properties
         .add(StringProperty('timeLabelLocation', timeLabelLocation.toString()));
     properties.add(StringProperty('timeLabelType', timeLabelType.toString()));
@@ -392,6 +448,8 @@ class _RenderProgressBar extends RenderBox {
     ThumbDragStartCallback? onDragStart,
     ThumbDragUpdateCallback? onDragUpdate,
     VoidCallback? onDragEnd,
+    VoidCallback? onTap,
+    required bool seekOnTap,
     required double barHeight,
     required Color baseBarColor,
     required Color progressBarColor,
@@ -414,6 +472,8 @@ class _RenderProgressBar extends RenderBox {
         _onDragStartUserCallback = onDragStart,
         _onDragUpdateUserCallback = onDragUpdate,
         _onDragEndUserCallback = onDragEnd,
+        _onTapUserCallback = onTap,
+        _seekOnTap = seekOnTap,
         _barHeight = barHeight,
         _baseBarColor = baseBarColor,
         _progressBarColor = progressBarColor,
@@ -429,17 +489,22 @@ class _RenderProgressBar extends RenderBox {
         _timeLabelTextStyle = timeLabelTextStyle,
         _timeLabelPadding = timeLabelPadding {
     _drag = HorizontalDragGestureRecognizer()
-      ..onDown = _onDragDown
       ..onStart = _onDragStart
       ..onUpdate = _onDragUpdate
       ..onEnd = _onDragEnd
       ..onCancel = _finishDrag
+      ..gestureSettings = gestureSettings;
+    _tap = TapGestureRecognizer()
+      ..onTapUp = _onTapUp
       ..gestureSettings = gestureSettings;
     _thumbValue = _proportionOfTotal(_progress);
   }
 
   // This is the gesture recognizer used to move the thumb.
   late HorizontalDragGestureRecognizer _drag;
+
+  // This is the gesture recognizer used to detect taps on the bar.
+  late TapGestureRecognizer _tap;
 
   // This is a value between 0.0 and 1.0 used to indicate the position on
   // the bar.
@@ -457,16 +522,6 @@ class _RenderProgressBar extends RenderBox {
   double get _defaultSidePadding {
     const minPadding = 5.0;
     return (_thumbCanPaintOutsideBar) ? thumbRadius + minPadding : minPadding;
-  }
-
-  // The Down event is the first event that is triggered. If null, the gesture
-  // will lose to other gesture recognizers that have handled tap / down.
-  // Also, may be the only event that will be received, if the user tapped,
-  // instead of dragging.
-  void _onDragDown(DragDownDetails details) {
-    _updateThumbPosition(details.localPosition);
-    onSeek?.call(_currentThumbDuration());
-    markNeedsPaint();
   }
 
   void _onDragStart(DragStartDetails details) {
@@ -497,6 +552,17 @@ class _RenderProgressBar extends RenderBox {
   void _finishDrag() {
     _userIsDraggingThumb = false;
     markNeedsPaint();
+  }
+
+  // Call onTap first and then check if the seekOnTap is requested.
+  // If 'true' then update the thumb position and invoke the onSeek callback.
+  void _onTapUp(TapUpDetails details) {
+    onTap?.call();
+    if (_seekOnTap) {
+      _updateThumbPosition(details.localPosition);
+      onSeek?.call(_currentThumbDuration());
+      markNeedsPaint();
+    }
   }
 
   Duration _currentThumbDuration() {
@@ -660,6 +726,24 @@ class _RenderProgressBar extends RenderBox {
     _onDragEndUserCallback = value;
   }
 
+  /// A callback when the bar is tapped
+  VoidCallback? get onTap => _onTapUserCallback;
+  VoidCallback? _onTapUserCallback;
+  set onTap(VoidCallback? value) {
+    if (value == _onTapUserCallback) {
+      return;
+    }
+    _onTapUserCallback = value;
+  }
+
+  /// A toggle to enable the onSeek callback on tap along with thumb tracking.
+  bool get seekOnTap => _seekOnTap;
+  bool _seekOnTap;
+  set seekOnTap(bool value) {
+    if (_seekOnTap == value) return;
+    _seekOnTap = value;
+  }
+
   /// The vertical thickness of the bar that the thumb moves along.
   double get barHeight => _barHeight;
   double _barHeight;
@@ -819,6 +903,7 @@ class _RenderProgressBar extends RenderBox {
     assert(debugHandleEvent(event, entry));
     if (event is PointerDownEvent) {
       _drag.addPointer(event);
+      _tap.addPointer(event);
     }
   }
 

--- a/test/audio_video_progress_bar_test.dart
+++ b/test/audio_video_progress_bar_test.dart
@@ -334,7 +334,7 @@ void main() {
       await tester.drag(find.byType(ProgressBar), const Offset(-100, 0));
       expect(seekCount, 1);
       expect(dragStartCount, 1);
-      expect(dragUpdateCount, 2);
+      expect(dragUpdateCount, 1);
       expect(dragEndCount, 1);
     });
 
@@ -367,10 +367,9 @@ void main() {
       // drag from the middle of the widget to the far left side
       await tester.drag(find.byType(ProgressBar), const Offset(-100, 0));
       expect(onSeekDuration, Duration.zero);
-      expect(onDragStartDuration, const Duration(minutes: 2, seconds: 30));
-      expect(onDragUpdateDurations[0],
+      expect(onDragStartDuration,
           const Duration(minutes: 1, seconds: 59, milliseconds: 231));
-      expect(onDragUpdateDurations[1], Duration.zero);
+      expect(onDragUpdateDurations[0], Duration.zero);
     });
 
     testWidgets('callbacks have accurate position values for no side labels',
@@ -397,12 +396,285 @@ void main() {
 
       // drag from the middle of the widget to the far left side
       await tester.drag(find.byType(ProgressBar), const Offset(-100, 0));
-      expect(onDragStartDetails.globalPosition, const Offset(400.0, 300.0));
-      expect(onDragStartDetails.localPosition, const Offset(100.0, 17.0));
-      expect(onDragDetails[0].globalPosition, const Offset(380.0, 300.0));
-      expect(onDragDetails[0].localPosition, const Offset(80.0, 17.0));
-      expect(onDragDetails[1].globalPosition, const Offset(300.0, 300.0));
-      expect(onDragDetails[1].localPosition, const Offset(0.0, 17.0));
+      expect(onDragStartDetails.globalPosition, const Offset(380.0, 300.0));
+      expect(onDragStartDetails.localPosition, const Offset(80.0, 17.0));
+      expect(onDragDetails[0].globalPosition, const Offset(300.0, 300.0));
+      expect(onDragDetails[0].localPosition, const Offset(0.0, 17.0));
+    });
+  });
+
+  group('Tap callbacks', () {
+    testWidgets('methods called the right number of times on tap',
+        (WidgetTester tester) async {
+      int seekCount = 0;
+      int dragStartCount = 0;
+      int dragUpdateCount = 0;
+      int dragEndCount = 0;
+      int tapCount = 0;
+      await tester.pumpWidget(withMaterialApp(
+        testWidget: ProgressBar(
+          progress: Duration.zero,
+          total: const Duration(minutes: 5),
+          onSeek: (duration) {
+            seekCount++;
+          },
+          onDragStart: (details) {
+            dragStartCount++;
+          },
+          onDragUpdate: (details) {
+            dragUpdateCount++;
+          },
+          onDragEnd: () {
+            dragEndCount++;
+          },
+          onTap: () {
+            tapCount++;
+          },
+        ),
+      ));
+
+      await tester.tap(find.byType(ProgressBar));
+      expect(seekCount, 1);
+      expect(dragStartCount, 0);
+      expect(dragUpdateCount, 0);
+      expect(dragEndCount, 0);
+      expect(tapCount, 1);
+    });
+
+    testWidgets('Taps have accurate duration values',
+        (WidgetTester tester) async {
+      Duration onSeekDuration = const Duration(seconds: 1);
+      await tester.pumpWidget(withMaterialApp(
+        testWidget: Center(
+          child: SizedBox(
+            width: 200,
+            child: ProgressBar(
+              progress: Duration.zero,
+              total: const Duration(minutes: 5),
+              onSeek: (duration) {
+                onSeekDuration = duration;
+              },
+            ),
+          ),
+        ),
+      ));
+
+      await tester.tap(find.byType(ProgressBar));
+      expect(onSeekDuration, const Duration(minutes: 2, seconds: 30));
+    });
+
+    testWidgets(
+        'When seekOnTap is false,'
+        ' taps call methods the right number of times',
+        (WidgetTester tester) async {
+      int seekCount = 0;
+      int dragStartCount = 0;
+      int dragUpdateCount = 0;
+      int dragEndCount = 0;
+      int tapCount = 0;
+      await tester.pumpWidget(withMaterialApp(
+        testWidget: ProgressBar(
+          progress: Duration.zero,
+          total: const Duration(minutes: 5),
+          onSeek: (duration) {
+            seekCount++;
+          },
+          onDragStart: (details) {
+            dragStartCount++;
+          },
+          onDragUpdate: (details) {
+            dragUpdateCount++;
+          },
+          onDragEnd: () {
+            dragEndCount++;
+          },
+          onTap: () {
+            tapCount++;
+          },
+          seekOnTap: false,
+        ),
+      ));
+
+      await tester.tap(find.byType(ProgressBar));
+      expect(seekCount, 0);
+      expect(dragStartCount, 0);
+      expect(dragUpdateCount, 0);
+      expect(dragEndCount, 0);
+      expect(tapCount, 1);
+    });
+
+    testWidgets('When seekOnTap is false, taps have accurate duration values',
+        (WidgetTester tester) async {
+      Duration onSeekDuration = const Duration(seconds: 1);
+      await tester.pumpWidget(withMaterialApp(
+        testWidget: Center(
+          child: SizedBox(
+            width: 200,
+            child: ProgressBar(
+              progress: Duration.zero,
+              total: const Duration(minutes: 5),
+              onSeek: (duration) {
+                onSeekDuration = duration;
+              },
+              seekOnTap: false,
+            ),
+          ),
+        ),
+      ));
+
+      await tester.tap(find.byType(ProgressBar));
+      expect(onSeekDuration, const Duration(seconds: 1));
+    });
+  });
+  group('drag callbacks in composite widgets', () {
+    testWidgets('methods called the right number of times in composite widgets',
+        (WidgetTester tester) async {
+      int seekCount = 0;
+      int dragStartCount = 0;
+      int dragUpdateCount = 0;
+      int dragEndCount = 0;
+      int tapCount = 0;
+      await tester.pumpWidget(withMaterialApp(
+        testWidget: GestureDetector(
+          onTap: () => debugPrint('Tap on Gesture Detector'),
+          onHorizontalDragStart: (_) => debugPrint('Drag on Gesture Detector'),
+          child: ProgressBar(
+            progress: Duration.zero,
+            total: const Duration(minutes: 5),
+            onSeek: (duration) {
+              seekCount++;
+            },
+            onDragStart: (details) {
+              dragStartCount++;
+            },
+            onDragUpdate: (details) {
+              dragUpdateCount++;
+            },
+            onDragEnd: () {
+              dragEndCount++;
+            },
+            onTap: () {
+              tapCount++;
+            },
+          ),
+        ),
+      ));
+
+      // drag from the middle of the widget to the far left side
+      await tester.drag(find.byType(ProgressBar), const Offset(-100, 0));
+      expect(seekCount, 1);
+      expect(dragStartCount, 1);
+      expect(dragUpdateCount, 1);
+      expect(dragEndCount, 1);
+      expect(tapCount, 0);
+    });
+
+    testWidgets('callbacks have accurate duration values in composite widgets',
+        (WidgetTester tester) async {
+      Duration onSeekDuration = const Duration(seconds: 1);
+      Duration onDragStartDuration = const Duration(seconds: 1);
+      List<Duration> onDragUpdateDurations = [];
+      await tester.pumpWidget(withMaterialApp(
+        testWidget: Center(
+          child: GestureDetector(
+            onTap: () => debugPrint('Tap on Gesture Detector'),
+            onHorizontalDragStart: (_) =>
+                debugPrint('Drag on Gesture Detector'),
+            child: SizedBox(
+              width: 200,
+              child: ProgressBar(
+                progress: Duration.zero,
+                total: const Duration(minutes: 5),
+                onSeek: (duration) {
+                  onSeekDuration = duration;
+                },
+                onDragStart: (details) {
+                  onDragStartDuration = details.timeStamp;
+                },
+                onDragUpdate: (details) {
+                  onDragUpdateDurations.add(details.timeStamp);
+                },
+              ),
+            ),
+          ),
+        ),
+      ));
+
+      // drag from the middle of the widget to the far left side
+      await tester.drag(find.byType(ProgressBar), const Offset(-100, 0));
+      expect(onSeekDuration, Duration.zero);
+      expect(onDragStartDuration,
+          const Duration(minutes: 1, seconds: 59, milliseconds: 231));
+      expect(onDragUpdateDurations[0], Duration.zero);
+    });
+  });
+
+  group('Tap callbacks in composite widgets', () {
+    testWidgets('methods called the right number of times on tap',
+        (WidgetTester tester) async {
+      int seekCount = 0;
+      int dragStartCount = 0;
+      int dragUpdateCount = 0;
+      int dragEndCount = 0;
+      int tapCount = 0;
+      await tester.pumpWidget(withMaterialApp(
+        testWidget: GestureDetector(
+          onTap: () => debugPrint('Tap on Gesture Detector'),
+          onHorizontalDragStart: (_) => debugPrint('Drag on Gesture Detector'),
+          child: ProgressBar(
+            progress: Duration.zero,
+            total: const Duration(minutes: 5),
+            onSeek: (duration) {
+              seekCount++;
+            },
+            onDragStart: (details) {
+              dragStartCount++;
+            },
+            onDragUpdate: (details) {
+              dragUpdateCount++;
+            },
+            onDragEnd: () {
+              dragEndCount++;
+            },
+            onTap: () {
+              tapCount++;
+            },
+          ),
+        ),
+      ));
+
+      await tester.tap(find.byType(ProgressBar));
+      expect(seekCount, 1);
+      expect(dragStartCount, 0);
+      expect(dragUpdateCount, 0);
+      expect(dragEndCount, 0);
+      expect(tapCount, 1);
+    });
+
+    testWidgets('Taps have accurate duration values',
+        (WidgetTester tester) async {
+      Duration onSeekDuration = const Duration(seconds: 1);
+      await tester.pumpWidget(withMaterialApp(
+        testWidget: Center(
+          child: GestureDetector(
+            onTap: () => debugPrint('Tap on Gesture Detector'),
+            onHorizontalDragStart: (_) =>
+                debugPrint('Drag on Gesture Detector'),
+            child: SizedBox(
+              width: 200,
+              child: ProgressBar(
+                progress: Duration.zero,
+                total: const Duration(minutes: 5),
+                onSeek: (duration) {
+                  onSeekDuration = duration;
+                },
+              ),
+            ),
+          ),
+        ),
+      ));
+      await tester.tap(find.byType(ProgressBar));
+      expect(onSeekDuration, const Duration(minutes: 2, seconds: 30));
     });
   });
 }


### PR DESCRIPTION
Based on discussions is PR #48, this commit attempts to fix the tap and drag issues (#44) by introducing a new tap gesture to deal with tap events. This is supported by two changes in the interface (that are backward compatible and wouldn't break previous clients)

`onTap` - An optional callback that is invoked when the user finishes tapping on the progress bar.

`seekOnTap` - A toggle (boolean) which determines whether a tap on the progress bar will cause the tracking thumb to move to the location of the tap and cause the onSeek to be invoked. The default is true, which mimics the behavior before this PR.

The documentation has been updated to reflect these changes

### Updates to Test cases
This commit also updates the test cases to test the changes described above.
It also introduces test cases that tests the widget in composition with a parent that competes with tap and drag gestures.