### PR TITLE
Add text scale factor property

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -94,7 +94,6 @@ class _FullExampleState extends State<FullExample> {
   TextStyle? _labelStyle;
   var _thumbRadius = 10.0;
   var _labelPadding = 0.0;
-  var _labelTextScaleFactor = 1.0;
   var _barHeight = 5.0;
   var _barCapShape = BarCapShape.round;
   Color? _baseBarColor;
@@ -137,7 +136,6 @@ class _FullExampleState extends State<FullExample> {
                     _labelLocationButtons(),
                     _labelTypeButtons(),
                     _labelSizeButtons(),
-                    _textScaleSizeButtons(),
                     _paddingSizeButtons(),
                     const SizedBox(height: 20),
                     const Text(
@@ -328,29 +326,6 @@ class _FullExampleState extends State<FullExample> {
     ]);
   }
 
-  Wrap _textScaleSizeButtons() {
-    return Wrap(children: [
-      OutlinedButton(
-        child: const Text('standard text scale'),
-        onPressed: () {
-          setState(() => _labelTextScaleFactor = 1.0);
-        },
-      ),
-      OutlinedButton(
-        child: const Text('2 text scale'),
-        onPressed: () {
-          setState(() => _labelTextScaleFactor = 2.0);
-        },
-      ),
-      OutlinedButton(
-        child: const Text('3 text scale'),
-        onPressed: () {
-          setState(() => _labelTextScaleFactor = 3.0);
-        },
-      ),
-    ]);
-  }
-
   Wrap _barHeightButtons() {
     return Wrap(children: [
       OutlinedButton(
@@ -445,6 +420,7 @@ class _FullExampleState extends State<FullExample> {
         final progress = durationState?.progress ?? Duration.zero;
         final buffered = durationState?.buffered ?? Duration.zero;
         final total = durationState?.total ?? Duration.zero;
+        final textScaleFactor = MediaQuery.textScaleFactorOf(context);
         return ProgressBar(
           progress: progress,
           buffered: buffered,
@@ -466,7 +442,7 @@ class _FullExampleState extends State<FullExample> {
           timeLabelType: _labelType,
           timeLabelTextStyle: _labelStyle,
           timeLabelPadding: _labelPadding,
-          timeLabelTextScaleFactor: _labelTextScaleFactor,
+          timeLabelTextScaleFactor: textScaleFactor,
         );
       },
     );

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -94,6 +94,7 @@ class _FullExampleState extends State<FullExample> {
   TextStyle? _labelStyle;
   var _thumbRadius = 10.0;
   var _labelPadding = 0.0;
+  var _labelTextScaleFactor = 1.0;
   var _barHeight = 5.0;
   var _barCapShape = BarCapShape.round;
   Color? _baseBarColor;
@@ -136,6 +137,7 @@ class _FullExampleState extends State<FullExample> {
                     _labelLocationButtons(),
                     _labelTypeButtons(),
                     _labelSizeButtons(),
+                    _textScaleSizeButtons(),
                     _paddingSizeButtons(),
                     const SizedBox(height: 20),
                     const Text(
@@ -326,6 +328,29 @@ class _FullExampleState extends State<FullExample> {
     ]);
   }
 
+  Wrap _textScaleSizeButtons() {
+    return Wrap(children: [
+      OutlinedButton(
+        child: const Text('standard text scale'),
+        onPressed: () {
+          setState(() => _labelTextScaleFactor = 1.0);
+        },
+      ),
+      OutlinedButton(
+        child: const Text('2 text scale'),
+        onPressed: () {
+          setState(() => _labelTextScaleFactor = 2.0);
+        },
+      ),
+      OutlinedButton(
+        child: const Text('3 text scale'),
+        onPressed: () {
+          setState(() => _labelTextScaleFactor = 3.0);
+        },
+      ),
+    ]);
+  }
+
   Wrap _barHeightButtons() {
     return Wrap(children: [
       OutlinedButton(
@@ -441,6 +466,7 @@ class _FullExampleState extends State<FullExample> {
           timeLabelType: _labelType,
           timeLabelTextStyle: _labelStyle,
           timeLabelPadding: _labelPadding,
+          timeLabelTextScaleFactor: _labelTextScaleFactor,
         );
       },
     );

--- a/lib/audio_video_progress_bar.dart
+++ b/lib/audio_video_progress_bar.dart
@@ -96,6 +96,7 @@ class ProgressBar extends LeafRenderObjectWidget {
     this.timeLabelType,
     this.timeLabelTextStyle,
     this.timeLabelPadding = 0.0,
+    this.timeLabelTextScaleFactor = 1.0,
   }) : super(key: key);
 
   /// The elapsed playing time of the media.
@@ -252,6 +253,11 @@ class ProgressBar extends LeafRenderObjectWidget {
   /// the progress bar and a negative number will move them closer.
   final double timeLabelPadding;
 
+  /// The `textScaleFactor` used by the time labels.
+  ///
+  /// The default is 1.0.
+  final double timeLabelTextScaleFactor;
+
   @override
   RenderObject createRenderObject(BuildContext context) {
     final theme = Theme.of(context);
@@ -280,6 +286,7 @@ class ProgressBar extends LeafRenderObjectWidget {
       timeLabelType: timeLabelType ?? TimeLabelType.totalTime,
       timeLabelTextStyle: textStyle,
       timeLabelPadding: timeLabelPadding,
+      timeLabelTextScaleFactor: timeLabelTextScaleFactor,
     );
   }
 
@@ -310,7 +317,8 @@ class ProgressBar extends LeafRenderObjectWidget {
       ..timeLabelLocation = timeLabelLocation ?? TimeLabelLocation.below
       ..timeLabelType = timeLabelType ?? TimeLabelType.totalTime
       ..timeLabelTextStyle = textStyle
-      ..timeLabelPadding = timeLabelPadding;
+      ..timeLabelPadding = timeLabelPadding
+      ..timeLabelTextScaleFactor = timeLabelTextScaleFactor;
   }
 
   @override
@@ -353,6 +361,8 @@ class ProgressBar extends LeafRenderObjectWidget {
     properties
         .add(DiagnosticsProperty('timeLabelTextStyle', timeLabelTextStyle));
     properties.add(DoubleProperty('timeLabelPadding', timeLabelPadding));
+    properties.add(
+        DoubleProperty('timeLabelTextScaleFactor', timeLabelTextScaleFactor));
   }
 }
 
@@ -425,6 +435,7 @@ class _RenderProgressBar extends RenderBox {
     required TimeLabelType timeLabelType,
     TextStyle? timeLabelTextStyle,
     double timeLabelPadding = 0.0,
+    double timeLabelTextScaleFactor = 1.0,
   })  : _total = total,
         _buffered = buffered,
         _onSeek = onSeek,
@@ -444,7 +455,8 @@ class _RenderProgressBar extends RenderBox {
         _timeLabelLocation = timeLabelLocation,
         _timeLabelType = timeLabelType,
         _timeLabelTextStyle = timeLabelTextStyle,
-        _timeLabelPadding = timeLabelPadding {
+        _timeLabelPadding = timeLabelPadding,
+        _timeLabelTextScaleFactor = timeLabelTextScaleFactor {
     _drag = _EagerHorizontalDragGestureRecognizer()
       ..onStart = _onDragStart
       ..onUpdate = _onDragUpdate
@@ -606,6 +618,7 @@ class _RenderProgressBar extends RenderBox {
     TextPainter textPainter = TextPainter(
       text: TextSpan(text: text, style: _timeLabelTextStyle),
       textDirection: TextDirection.ltr,
+      textScaleFactor: _timeLabelTextScaleFactor,
     );
     textPainter.layout(minWidth: 0, maxWidth: double.infinity);
     return textPainter;
@@ -815,6 +828,17 @@ class _RenderProgressBar extends RenderBox {
   set timeLabelPadding(double value) {
     if (_timeLabelPadding == value) return;
     _timeLabelPadding = value;
+    markNeedsLayout();
+  }
+
+  /// The text scale factor for the `progress` and `total` text labels.
+  /// By default the value is 1.0.
+  double get timeLabelTextScaleFactor => _timeLabelTextScaleFactor;
+  double _timeLabelTextScaleFactor;
+  set timeLabelTextScaleFactor(double value) {
+    if (_timeLabelTextScaleFactor == value) return;
+    _timeLabelTextScaleFactor = value;
+    _clearLabelCache();
     markNeedsLayout();
   }
 

--- a/test/audio_video_progress_bar_test.dart
+++ b/test/audio_video_progress_bar_test.dart
@@ -40,6 +40,7 @@ void main() {
         timeLabelLocation: TimeLabelLocation.sides,
         timeLabelType: TimeLabelType.remainingTime,
         timeLabelTextStyle: const TextStyle(color: Color(0x00000000)),
+        timeLabelTextScaleFactor: 1.5,
       ),
     );
 
@@ -65,6 +66,7 @@ void main() {
     expect(progressBar.timeLabelTextStyle,
         const TextStyle(color: Color(0x00000000)));
     expect(progressBar.timeLabelPadding, 0.0);
+    expect(progressBar.timeLabelTextScaleFactor, 1.5);
   });
 
   testWidgets('TimeLabelLocation.below size correct',


### PR DESCRIPTION
For the bug #61 , this commit adds a `timeLabelTextScaleFactor` property to `ProgressBar`. This is mainly related with Accessibility and will allow the `ProgressBar` `progress` and `total` labels to scale based on device text scale. The labels will not scale if no value is passed to `timeLabelTextScaleFactor` in `ProgressBar`.