### PR TITLE
Improve accessibility support for gesture-based adjustments

### DIFF
--- a/lib/audio_video_progress_bar.dart
+++ b/lib/audio_video_progress_bar.dart
@@ -1124,6 +1124,7 @@ class _RenderProgressBar extends RenderBox {
     _thumbValue = (newValue).clamp(0.0, 1.0);
     markNeedsPaint();
     markNeedsSemanticsUpdate();
+    onSeek?.call(_currentThumbDuration());
   }
 
   void decreaseAction() {
@@ -1131,5 +1132,6 @@ class _RenderProgressBar extends RenderBox {
     _thumbValue = (newValue).clamp(0.0, 1.0);
     markNeedsPaint();
     markNeedsSemanticsUpdate();
+    onSeek?.call(_currentThumbDuration());
   }
 }


### PR DESCRIPTION
This commit enhances the ProgressBar widget's accessibility by ensuring that the onSeek callback is triggered when accessibility gestures are used to increase or decrease the progress. Previously, while the ProgressBar updated its visual progress in response to accessibility gestures, it did not correctly trigger the external onSeek callback, leaving the associated playing media player's state unchanged. This change ensures that users relying on screen readers and other accessibility tools can accurately control media playback through gesture-based interactions.

Key Changes:
- Added onSeek?.call(_currentThumbDuration()); to the increaseAction and decreaseAction methods within the _RenderProgressBar class.

Example Usage:
                  ProgressBar(
                    progress: Duration(seconds: value),
                    buffered: Duration(seconds: buffer),
                    total: Duration(seconds: max),
                    progressBarColor: colorTheme,
                    ……
                    onSeek: (duration) {
                      _.onChangedSliderEnd();
                      _.onChangedSlider(duration.inSeconds.toDouble());
                      _.seekTo(Duration(seconds: duration.inSeconds),
                          type: 'slider');
                      SemanticsService.announce(
                          "${(duration.inSeconds / max * 100).round()}%",
                          TextDirection.ltr);
                    },
                  ), // ProgressBar
As its shows, I have to trigger SemanticsService.announce to notify screen reader the progress percentage, so I tried this. 

The gesture is activated by first touching the progress bar, then double-tapping to set it as the focus, followed by swiping left/right (or up/down) to adjust the progress.

There might be more elegant ways to achieve the same outcome. I am open to feedback and suggestions for improving this implementation further. Thanks a lot!